### PR TITLE
Synchronize cache creation, allow workspace ref paths, log username

### DIFF
--- a/lib/src/htmlfilesetserv/HTMLFileSetHTTPServer.java
+++ b/lib/src/htmlfilesetserv/HTMLFileSetHTTPServer.java
@@ -345,10 +345,8 @@ public class HTMLFileSetHTTPServer extends HttpServlet {
 		if (at != null && !at.trim().isEmpty()) {
 			return auth.validateToken(at);
 		}
-		System.out.println("cookies: " + request.getCookies());
 		if (request.getCookies() != null) {
 			for (final Cookie c: request.getCookies()) {
-				System.out.println(c.getName());
 				if (c.getName().equals("token")) {
 					return auth.validateToken(c.getValue());
 				}
@@ -369,6 +367,7 @@ public class HTMLFileSetHTTPServer extends HttpServlet {
 		
 		final Path rootpath = scratch.resolve(absref);
 		final Path filepath = rootpath.resolve(refAndPath.path);
+		//TODO NOW synchronize (on absref?)
 		if (Files.isDirectory(rootpath)) {
 			logMessage("Using cache for object " + absref, ri);
 			return filepath;


### PR DESCRIPTION
Adds synchronization blocks around the cache creation part of the code to avoid two threads building the same cache at the same time and clobbering each other's cache momentarily or reading from a half complete cache. May need a cache reaper at some point. Keeps a hash of lock objects so the synchronization block is keyed to a specific absolute workspace reference.

Adds the ability to provide workspace reference path when retrieving html files.

Logs user names.