### PR TITLE
update to latest shock jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,13 @@ RUN sudo apt-get install nano \
 	&& ln -s /usr/lib/jvm/java-8-openjdk-amd64 java \
 	&& ls -l
 
+# get most up to date jars, note will be cached so change this RUN to update
+RUN cd /kb/dev_container/modules/jars \
+    && git pull \
+    && . /kb/dev_container/user-env.sh \
+    && make deploy \
+    && echo "this is only here to force an update: 1"
+
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 # -----------------------------------------

--- a/build.xml
+++ b/build.xml
@@ -39,7 +39,7 @@
     <include name="kbase/workspace/WorkspaceService-0.5.0.jar"/>
     <include name="mustache/compiler-0.9.3.jar"/>
     <!-- shock client requirements -->
-    <include name="kbase/shock/shock-client-0.0.14.jar"/>
+    <include name="kbase/shock/shock-client-0.0.15.jar"/>
     <include name="apache_commons/http/httpclient-4.3.1.jar"/>
     <include name="apache_commons/http/httpcore-4.3.jar"/>
     <include name="apache_commons/http/httpmime-4.3.1.jar"/>

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     java
 
 module-version:
-    0.0.4
+    0.0.5
 
 owners:
     [gaprice]


### PR DESCRIPTION
Fixes issue when pulling shock nodes that have attributes that aren't a
map