### PR TITLE
[SCT-816] Limit max memory to 5G

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ TEST_SCRIPT_NAME = run_tests.sh
 KB_RUNTIME ?= /kb/runtime
 ANT_HOME ?= $(KB_RUNTIME)/ant
 ANT = $(ANT_HOME)/bin/ant
+JAVA_MAX_MEM = -Xmx5G
 
 .PHONY: test
 
@@ -48,7 +49,7 @@ build-startup-script:
 	echo 'script_dir=$$(dirname "$$(readlink -f "$$0")")' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
 	echo 'cd $(SCRIPTS_DIR)' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
 	echo 'java -cp $(JARS_DIR)/jetty/jetty-start-7.0.0.jar:$(JARS_DIR)/jetty/jetty-all-7.0.0.jar:$(JARS_DIR)/servlet/servlet-api-2.5.jar \
-		-DKB_DEPLOYMENT_CONFIG=$$script_dir/../deploy.cfg -Djetty.port=5000 org.eclipse.jetty.start.Main jetty.xml' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
+		$(JAVA_MAX_MEM) -DKB_DEPLOYMENT_CONFIG=$$script_dir/../deploy.cfg -Djetty.port=5000 org.eclipse.jetty.start.Main jetty.xml' >> $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
 	chmod +x $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME)
 
 build-test-script:


### PR DESCRIPTION
```
~/localgit/kbaseapps/HTMLFileSetServ/test_local$ ./run_bash.sh 
I have no name!@b48da03d7a86:/kb/module$ cat scripts/start_server.sh 
#!/bin/bash
script_dir=$(dirname "$(readlink -f "$0")")
cd scripts
java -cp
/kb/deployment/lib/jars/jetty/jetty-start-7.0.0.jar:/kb/deployment/lib/jars/jetty/jetty-all-7.0.0.jar:/kb/deployment/lib/jars/servlet/servlet-api-2.5.jar
\
	-Xmx5G -DKB_DEPLOYMENT_CONFIG=$script_dir/../deploy.cfg
-Djetty.port=5000 org.eclipse.jetty.start.Main jetty.xml
I have no name!@b48da03d7a86:/kb/module$
```